### PR TITLE
Atualização de imagens (sdk, runtime) .net core 2.2

### DIFF
--- a/src/DevWeek.WebApp/Dockerfile
+++ b/src/DevWeek.WebApp/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-stretch-slim  AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.2-sdk-stretch AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2.105  AS build
 WORKDIR /src
 COPY *.sln ./
 COPY DevWeek.Worker/DevWeek.Worker.csproj DevWeek.Worker/

--- a/src/DevWeek.WebApp/wwwroot/js/NavController.js
+++ b/src/DevWeek.WebApp/wwwroot/js/NavController.js
@@ -1,5 +1,5 @@
 ﻿
 app.controller('NavController', ['$scope', '$q', ($scope, $q) => {
 
-    $scope.title = "DevWeek 2017";
+    $scope.title = "Cloud Native .NET - 2022";
 }]);

--- a/src/DevWeek.Worker/Dockerfile
+++ b/src/DevWeek.Worker/Dockerfile
@@ -1,10 +1,12 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-stretch-slim  AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim  AS base
 WORKDIR /app
-RUN apt-get update && apt-get install libav-tools python2.7-minimal ca-certificates -y && cp /usr/bin/python2.7 /usr/bin/python
-RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl && chmod a+rx /usr/local/bin/youtube-dl
+RUN apt-get update && apt-get install ca-certificates -y
+RUN update-ca-certificates
+RUN apt-get install ffmpeg python2.7 ca-certificates -y && cp /usr/bin/python2.7 /usr/bin/python
+RUN curl --insecure -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl && chmod a+rx /usr/local/bin/youtube-dl
 
 
-FROM microsoft/dotnet:2.2-sdk-stretch AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2.105 AS build
 WORKDIR /src
 COPY *.sln ./
 COPY DevWeek.Worker/DevWeek.Worker.csproj DevWeek.Worker/

--- a/src/DevWeek.Worker/Dockerfile
+++ b/src/DevWeek.Worker/Dockerfile
@@ -1,10 +1,14 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim  AS base
 WORKDIR /app
-RUN apt-get update && apt-get install ca-certificates -y
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN curl -k https://curl.se/ca/cacert.pem > cacert.pem
+RUN apt-get install ca-certificates
+RUN openssl x509 -outform der -in cacert.pem -out cacert.crt
+RUN cp cacert.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
-RUN apt-get install ffmpeg python2.7 ca-certificates -y && cp /usr/bin/python2.7 /usr/bin/python
-RUN curl --insecure -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl && chmod a+rx /usr/local/bin/youtube-dl
-
+RUN apt-get install libav-tools python2.7-minimal ca-certificates -y && cp /usr/bin/python2.7 /usr/bin/python
+RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl && chmod a+rx /usr/local/bin/youtube-dl
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2.105 AS build
 WORKDIR /src

--- a/src/docker-compose.ci.build.yml
+++ b/src/docker-compose.ci.build.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   ci-build:
-    image: microsoft/dotnet:2.2-sdk-stretch
+    image: mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim
     volumes:
       - .:/src
 #    extra_hosts:

--- a/src/docker-compose.dev.yml
+++ b/src/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     ports:
-      - "80"
+      - "80:80"
 
 
 


### PR DESCRIPTION
# Alterações ✏️
- Foi colocado imagens do MCR (Microsoft Container Registry )
- Foi identificado o motivo do libav-tools não instalar, tinha que atualizar alguns pacotes, foi implementado

# Resultado 🚀

![image](https://user-images.githubusercontent.com/8622005/149855656-0792b11d-2289-425e-aa4e-5d2b2c357212.png)

# Referências 📁

[https://devblogs.microsoft.com/dotnet/net-core-2-1-container-images-will-be-deleted-from-docker-hub/](url)
[https://devblogs.microsoft.com/dotnet/net-core-container-images-now-published-to-microsoft-container-registry/](url)
